### PR TITLE
feat: allow bot to respond to mentions in any channel

### DIFF
--- a/apps/bot/src/lib/shouldRespond.ts
+++ b/apps/bot/src/lib/shouldRespond.ts
@@ -18,17 +18,17 @@ export async function shouldRespond(message: Message): Promise<ShouldRespondResu
     return { shouldRespond: true, confidence: 100, reason: 'Direct message' };
   }
 
-  // Only respond in #omega channel (or DMs)
-  const channelName = (message.channel as any).name;
-  if (channelName !== 'omega') {
-    console.log(`   ⏭️  Ignoring message from #${channelName} (only responding in #omega)`);
-    return { shouldRespond: false, confidence: 100, reason: `Wrong channel (#${channelName})` };
-  }
-
-  // Check if bot was mentioned
+  // Check if bot was mentioned - respond in ANY channel when directly tagged
   const botMentioned = message.mentions.users.has(message.client.user!.id);
   if (botMentioned) {
     return { shouldRespond: true, confidence: 100, reason: 'Direct mention' };
+  }
+
+  // For non-mentions, only respond in #omega channel
+  const channelName = (message.channel as any).name;
+  if (channelName !== 'omega') {
+    console.log(`   ⏭️  Ignoring message from #${channelName} (only responding in #omega unless mentioned)`);
+    return { shouldRespond: false, confidence: 100, reason: `Wrong channel (#${channelName})` };
   }
 
   // Check if message is a reply to the bot


### PR DESCRIPTION
## Summary

Implements #129 - Bot now responds to direct mentions in any Discord channel.

## Changes
- Modified `src/lib/shouldRespond.ts` to check for mentions before channel restriction
- Bot responds to direct mentions (`<@1438866165475708979>`) in ANY channel
- Message history (last 20 messages) already fetched for context in all channels
- Preserves existing behavior: non-mention messages only trigger in #omega

## Testing
- Mention the bot in a non-omega channel to verify it responds
- Verify it includes context from recent messages
- Verify existing #omega channel behavior unchanged

—
Generated with [Claude Code](https://claude.ai/code)